### PR TITLE
Fix 'select' method to allow deselecting selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 6.1.2
-* Fix 'select' method to allow deselecting selection
+* Fix 'select' method in MockISelectionManager to allow deselecting selection
 * Check if 'callback' is defined in MockISelectionManager
 * Add tests for MockISelectionManager
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 6.1.2
 * Fix 'select' method to allow deselecting selection
+* Check if 'callback' is defined in MockISelectionManager
 
 ## 6.1.1
 * powerbi-visuals-api update to 5.9.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 6.1.2
+* Fix 'select' method to allow deselecting selection
 
 ## 6.1.1
 * powerbi-visuals-api update to 5.9.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 6.1.2
 * Fix 'select' method to allow deselecting selection
 * Check if 'callback' is defined in MockISelectionManager
+* Add tests for MockISelectionManager
 
 ## 6.1.1
 * powerbi-visuals-api update to 5.9.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "powerbi-visuals-utils-testutils",
-  "version": "6.1.1",
+  "version": "6.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "powerbi-visuals-utils-testutils",
-      "version": "6.1.1",
+      "version": "6.1.2",
       "license": "MIT",
       "dependencies": {
         "d3-array": "3.2.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "powerbi-visuals-utils-testutils",
-  "version": "6.1.1",
+  "version": "6.1.2",
   "description": "powerbi-visuals-utils-testutils",
   "main": "lib/index.js",
   "module": "lib/index.js",

--- a/src/mocks/mockISelectionManager.ts
+++ b/src/mocks/mockISelectionManager.ts
@@ -133,6 +133,8 @@ export class MockISelectionManager implements ISelectionManager {
     }
 
     public simutateSelection(selections: ISelectionId[]): void {
-        this.callback(selections);
+        if (this.callback && typeof this.callback === "function") {
+            this.callback(selections);
+        }
     }
 }

--- a/test/mocks/mockISelectionManagerTest.ts
+++ b/test/mocks/mockISelectionManagerTest.ts
@@ -133,7 +133,7 @@ describe("MockISelectionManager", () => {
 
             const selectedIds: ISelectionId[] = selectionManager.getSelectionIds();
             expect(selectedIds).toHaveSize(1);
-            expect(selectedIds[0].equals(selectionId)).toBeTruthy();
+            expect(selectedIds[0]).toEqual(selectionId);
         });
 
         it("should toggle a selection", () => {
@@ -155,7 +155,7 @@ describe("MockISelectionManager", () => {
 
             const selectedIds: ISelectionId[] = selectionManager.getSelectionIds();
             expect(selectedIds).toHaveSize(1);
-            expect(selectedIds[0].equals(selectionId1)).toBeTruthy();
+            expect(selectedIds[0]).toEqual(selectionId1);
         });
 
         it("should not update the selection when selection array is empty", () => {
@@ -166,7 +166,7 @@ describe("MockISelectionManager", () => {
 
             const selectedIds: ISelectionId[] = selectionManager.getSelectionIds();
             expect(selectedIds).toHaveSize(1);
-            expect(selectedIds[0].equals(selectionId)).toBeTruthy();
+            expect(selectedIds[0]).toEqual(selectionId);
         })
 
         it("should add multiple selections at once", () => {
@@ -178,9 +178,9 @@ describe("MockISelectionManager", () => {
 
             const selectedIds: ISelectionId[] = selectionManager.getSelectionIds();
             expect(selectedIds).toHaveSize(3);
-            expect(selectedIds[0].equals(selectionId0)).toBeTruthy();
-            expect(selectedIds[1].equals(selectionId1)).toBeTruthy();
-            expect(selectedIds[2].equals(selectionId2)).toBeTruthy();
+            expect(selectedIds[0]).toEqual(selectionId0);
+            expect(selectedIds[1]).toEqual(selectionId1);
+            expect(selectedIds[2]).toEqual(selectionId2);
         });
 
         it("should add multiple selections with multiSelection", () => {
@@ -194,9 +194,9 @@ describe("MockISelectionManager", () => {
 
             const selectedIds: ISelectionId[] = selectionManager.getSelectionIds();
             expect(selectedIds).toHaveSize(3);
-            expect(selectedIds[0].equals(selectionId0)).toBeTruthy();
-            expect(selectedIds[1].equals(selectionId1)).toBeTruthy();
-            expect(selectedIds[2].equals(selectionId2)).toBeTruthy();
+            expect(selectedIds[0]).toEqual(selectionId0);
+            expect(selectedIds[1]).toEqual(selectionId1);
+            expect(selectedIds[2]).toEqual(selectionId2);
         });
 
         it("should toggle a selection with multiSelection", () => {
@@ -209,8 +209,8 @@ describe("MockISelectionManager", () => {
 
             const selectedIds: ISelectionId[] = selectionManager.getSelectionIds();
             expect(selectedIds).toHaveSize(2);
-            expect(selectedIds[0].equals(selectionId0)).toBeTruthy();
-            expect(selectedIds[1].equals(selectionId1)).toBeTruthy();
+            expect(selectedIds[0]).toEqual(selectionId0);
+            expect(selectedIds[1]).toEqual(selectionId1);
         });
 
         it("should replace a selection with passed array of selectionIds", () => {
@@ -224,10 +224,10 @@ describe("MockISelectionManager", () => {
 
             const selectedIds: ISelectionId[] = selectionManager.getSelectionIds();
             expect(selectedIds).toHaveSize(2);
-            expect(selectedIds[0].equals(selectionId0)).toBeFalsy();
-            expect(selectedIds[1].equals(selectionId1)).toBeFalsy();
-            expect(selectedIds[0].equals(selectionId2)).toBeTruthy();
-            expect(selectedIds[1].equals(selectionId3)).toBeTruthy();
+            expect(selectedIds[0]).not.toEqual(selectionId0);
+            expect(selectedIds[1]).not.toEqual(selectionId1);
+            expect(selectedIds[0]).toEqual(selectionId2);
+            expect(selectedIds[1]).toEqual(selectionId3);
         });
 
         it("should merge a selection with passed array of selectionIds", () => {
@@ -241,10 +241,10 @@ describe("MockISelectionManager", () => {
 
             const selectedIds: ISelectionId[] = selectionManager.getSelectionIds();
             expect(selectedIds).toHaveSize(4);
-            expect(selectedIds[0].equals(selectionId0)).toBeTruthy();
-            expect(selectedIds[1].equals(selectionId1)).toBeTruthy();
-            expect(selectedIds[2].equals(selectionId2)).toBeTruthy();
-            expect(selectedIds[3].equals(selectionId3)).toBeTruthy();
+            expect(selectedIds[0]).toEqual(selectionId0);
+            expect(selectedIds[1]).toEqual(selectionId1);
+            expect(selectedIds[2]).toEqual(selectionId2);
+            expect(selectedIds[3]).toEqual(selectionId3);
         });
     });
 });

--- a/test/mocks/mockISelectionManagerTest.ts
+++ b/test/mocks/mockISelectionManagerTest.ts
@@ -1,0 +1,250 @@
+/*
+ *  Power BI Visualizations
+ *
+ *  Copyright (c) Microsoft Corporation
+ *  All rights reserved.
+ *  MIT License
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the ""Software""), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ *  all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ *  THE SOFTWARE.
+ */
+
+import powerbi from "powerbi-visuals-api";
+import { createSelectionId } from "../../src/mocks/mocks";
+import { MockISelectionManager } from "../../src/mocks/mockISelectionManager";
+
+import ISelectionId = powerbi.visuals.ISelectionId;
+
+describe("MockISelectionManager", () => {
+    let selectionManager: MockISelectionManager;
+
+    beforeEach(() => {
+        selectionManager = new MockISelectionManager();
+    });
+
+    describe("clear", () => {
+        it("should have an empty selection", () => {
+            expect(selectionManager.hasSelection()).toBeFalsy();
+        });
+
+        it("should clear the selection", () => {
+            const selectionId: ISelectionId = createSelectionId("1");
+
+            selectionManager.select(selectionId);
+            selectionManager.clear();
+
+            expect(selectionManager.getSelectionIds()).toHaveSize(0);
+            expect(selectionManager.hasSelection()).toBeFalsy();
+        })
+    });
+
+    describe("hasSelection", () => {
+        it("should return false when there is no selection", () => {
+            expect(selectionManager.hasSelection()).toBeFalsy();
+        });
+
+        it("should return true when there is a selection", () => {
+            const selectionId: ISelectionId = createSelectionId("1");
+
+            selectionManager.select(selectionId);
+
+            expect(selectionManager.hasSelection()).toBeTruthy();
+        });
+
+        it("should return false when the selection is cleared", () => {
+            const selectionId: ISelectionId = createSelectionId("1");
+
+            selectionManager.select(selectionId);
+            selectionManager.clear();
+
+            expect(selectionManager.hasSelection()).toBeFalsy();
+        });
+
+        it("should return false when selection is toggled", () => {
+            const selectionId: ISelectionId = createSelectionId("1");
+
+            selectionManager.select(selectionId);
+            selectionManager.select(selectionId);
+
+            expect(selectionManager.hasSelection()).toBeFalsy();
+        });
+    });
+
+    describe("getSelectionIds", () => {
+        it("should return an empty array when there is no selection", () => {
+            expect(selectionManager.getSelectionIds()).toHaveSize(0);
+        });
+
+        it("should return an array with a selection", () => {
+            const selectionId: ISelectionId = createSelectionId("1");
+
+            selectionManager.select(selectionId);
+
+            const selectedIds: ISelectionId[] = selectionManager.getSelectionIds();
+            expect(selectedIds).toHaveSize(1);
+        });
+    });
+
+    describe("containsSelection", () => {
+        it("should return false when there is no selection", () => {
+            const selectionId: ISelectionId = createSelectionId("1");
+
+            expect(selectionManager.containsSelection(selectionId)).toBeFalsy();
+        });
+
+        it("should return true when the selection is present", () => {
+            const selectionId: ISelectionId = createSelectionId("1");
+
+            selectionManager.select(selectionId);
+
+            expect(selectionManager.containsSelection(selectionId)).toBeTruthy();
+        });
+
+        it("should return false when the selection is not present", () => {
+            const selectionId: ISelectionId = createSelectionId("1");
+            const otherSelectionId: ISelectionId = createSelectionId("2");
+
+            selectionManager.select(selectionId);
+
+            expect(selectionManager.containsSelection(otherSelectionId)).toBeFalsy();
+        });
+    });
+
+    describe("select", () => {
+        it("should add a selection", () => {
+            const selectionId: ISelectionId = createSelectionId("1");
+
+            selectionManager.select(selectionId);
+
+            const selectedIds: ISelectionId[] = selectionManager.getSelectionIds();
+            expect(selectedIds).toHaveSize(1);
+            expect(selectedIds[0].equals(selectionId)).toBeTruthy();
+        });
+
+        it("should toggle a selection", () => {
+            const selectionId: ISelectionId = createSelectionId("1");
+
+            selectionManager.select(selectionId);
+            selectionManager.select(selectionId);
+
+            const selectedIds: ISelectionId[] = selectionManager.getSelectionIds();
+            expect(selectedIds).toHaveSize(0);
+        });
+
+        it("should replace a selection", () => {
+            const selectionId0: ISelectionId = createSelectionId("0");
+            const selectionId1: ISelectionId = createSelectionId("1");
+
+            selectionManager.select(selectionId0);
+            selectionManager.select(selectionId1);
+
+            const selectedIds: ISelectionId[] = selectionManager.getSelectionIds();
+            expect(selectedIds).toHaveSize(1);
+            expect(selectedIds[0].equals(selectionId1)).toBeTruthy();
+        });
+
+        it("should not update the selection when selection array is empty", () => {
+            const selectionId: ISelectionId = createSelectionId("1");
+
+            selectionManager.select(selectionId);
+            selectionManager.select([]);
+
+            const selectedIds: ISelectionId[] = selectionManager.getSelectionIds();
+            expect(selectedIds).toHaveSize(1);
+            expect(selectedIds[0].equals(selectionId)).toBeTruthy();
+        })
+
+        it("should add multiple selections at once", () => {
+            const selectionId0: ISelectionId = createSelectionId("0");
+            const selectionId1: ISelectionId = createSelectionId("1");
+            const selectionId2: ISelectionId = createSelectionId("2");
+
+            selectionManager.select([selectionId0, selectionId1, selectionId2]);
+
+            const selectedIds: ISelectionId[] = selectionManager.getSelectionIds();
+            expect(selectedIds).toHaveSize(3);
+            expect(selectedIds[0].equals(selectionId0)).toBeTruthy();
+            expect(selectedIds[1].equals(selectionId1)).toBeTruthy();
+            expect(selectedIds[2].equals(selectionId2)).toBeTruthy();
+        });
+
+        it("should add multiple selections with multiSelection", () => {
+            const selectionId0: ISelectionId = createSelectionId("0");
+            const selectionId1: ISelectionId = createSelectionId("1");
+            const selectionId2: ISelectionId = createSelectionId("2");
+
+            selectionManager.select(selectionId0);
+            selectionManager.select(selectionId1, true);
+            selectionManager.select(selectionId2, true);
+
+            const selectedIds: ISelectionId[] = selectionManager.getSelectionIds();
+            expect(selectedIds).toHaveSize(3);
+            expect(selectedIds[0].equals(selectionId0)).toBeTruthy();
+            expect(selectedIds[1].equals(selectionId1)).toBeTruthy();
+            expect(selectedIds[2].equals(selectionId2)).toBeTruthy();
+        });
+
+        it("should toggle a selection with multiSelection", () => {
+            const selectionId0: ISelectionId = createSelectionId("0");
+            const selectionId1: ISelectionId = createSelectionId("1");
+            const selectionId2: ISelectionId = createSelectionId("2");
+
+            selectionManager.select([selectionId0, selectionId1, selectionId2]);
+            selectionManager.select(selectionId2, true);
+
+            const selectedIds: ISelectionId[] = selectionManager.getSelectionIds();
+            expect(selectedIds).toHaveSize(2);
+            expect(selectedIds[0].equals(selectionId0)).toBeTruthy();
+            expect(selectedIds[1].equals(selectionId1)).toBeTruthy();
+        });
+
+        it("should replace a selection with passed array of selectionIds", () => {
+            const selectionId0: ISelectionId = createSelectionId("0");
+            const selectionId1: ISelectionId = createSelectionId("1");
+            const selectionId2: ISelectionId = createSelectionId("2");
+            const selectionId3: ISelectionId = createSelectionId("3");
+
+            selectionManager.select([selectionId0, selectionId1]);
+            selectionManager.select([selectionId2, selectionId3]);
+
+            const selectedIds: ISelectionId[] = selectionManager.getSelectionIds();
+            expect(selectedIds).toHaveSize(2);
+            expect(selectedIds[0].equals(selectionId0)).toBeFalsy();
+            expect(selectedIds[1].equals(selectionId1)).toBeFalsy();
+            expect(selectedIds[0].equals(selectionId2)).toBeTruthy();
+            expect(selectedIds[1].equals(selectionId3)).toBeTruthy();
+        });
+
+        it("should merge a selection with passed array of selectionIds", () => {
+            const selectionId0: ISelectionId = createSelectionId("0");
+            const selectionId1: ISelectionId = createSelectionId("1");
+            const selectionId2: ISelectionId = createSelectionId("2");
+            const selectionId3: ISelectionId = createSelectionId("3");
+
+            selectionManager.select([selectionId0, selectionId1]);
+            selectionManager.select([selectionId2, selectionId3], true);
+
+            const selectedIds: ISelectionId[] = selectionManager.getSelectionIds();
+            expect(selectedIds).toHaveSize(4);
+            expect(selectedIds[0].equals(selectionId0)).toBeTruthy();
+            expect(selectedIds[1].equals(selectionId1)).toBeTruthy();
+            expect(selectedIds[2].equals(selectionId2)).toBeTruthy();
+            expect(selectedIds[3].equals(selectionId3)).toBeTruthy();
+        });
+    });
+});


### PR DESCRIPTION
* Fix 'select' method to allow deselecting selection
* Check if 'callback' is defined in MockISelectionManager (as in API)
* Add tests for MockISelectionManager

Please, view the [source code](https://dev.azure.com/powerbi/_git/PowerBIClients?path=/src/Clients/VisualHostCore/versioning/hostComponents/selectionManager.ts&version=GBmaster&line=192&lineEnd=227&lineStartColumn=1&lineEndColumn=1&lineStyle=plain&_a=contents) for 'select' method.